### PR TITLE
fix: attach the listener for the aura transaction end event

### DIFF
--- a/src/LightningInspectorInjectedScript.js
+++ b/src/LightningInspectorInjectedScript.js
@@ -163,6 +163,13 @@ function AuraInspector() {
             console.error('Lightning Inspector: Error initializing page hooks', e);
         }
 
+        try {
+            // Transactions Tab
+            bootstrapTransactionReporting();
+        } catch (e) {
+            console.error('Lightning Inspector: Error initializing page hooks for transactions', e);
+        }
+
         window.postMessage(
             {
                 action: 'AuraInspector:bootstrap',


### PR DESCRIPTION
The bootstrap function seems to not include a call to attach a listener on the Aura transaction end event.

Update it to include it.