### PR TITLE
Switch to only use salesforce urls

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,8 +25,8 @@
         "tabs",
         "background",
         "contextMenus",
-        "http://*/",
-        "https://*/",
+        "https://*.force.com/*",
+        "https://*.salesforce.com/*",
         "contentSettings",
         "idle"
     ],


### PR DESCRIPTION
The rest of the permissions in the list are needed so we can try and scope down to using salesforce only URLs and see if that is enough to address the minimum permission policy.